### PR TITLE
Fixed Unmount bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## [0.2.0] March 16, 2022
+
+### Breaking Changes
+- Src insert placeholder ids must now include the tablekey. i.e.: "$sorcery:user:1" instead of "$sorcery:1"
+
+### Deprecations
+- Src Access implementation still exists but should not be used directly. Use Src.get_in and Src.put_in, instead of get_in and put_in.
+
+### Other Changes
+- Updated Readme
+- Added the ability to insert multiple entities, that refer to other placeholder entities, on the fly.
+- Rebuilt the entire Ecto.Adapter, with better tests, type contracts, and reliability.

--- a/lib/live_helpers.ex
+++ b/lib/live_helpers.ex
@@ -32,8 +32,8 @@ defmodule Sorcery.LiveHelper do
       end
 
 
-      def sorcery_unmount(pid) do
-        unquote(client).unmount(pid)
+      def sorcery_unmount(pids) do
+        unquote(client).unmount(pids)
       end
 
 

--- a/lib/portal/portal_monitor.ex
+++ b/lib/portal/portal_monitor.ex
@@ -22,7 +22,9 @@ defmodule Sorcery.PortalMonitor do
 
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    state[pid].sorcery_unmount(pid)
+    if Process.alive?(pid) do
+      state[pid].sorcery_unmount(pid)
+    end
     new_state = Map.delete(state, pid)
     {:noreply, new_state}
   end

--- a/lib/portal/portal_monitor.ex
+++ b/lib/portal/portal_monitor.ex
@@ -22,10 +22,24 @@ defmodule Sorcery.PortalMonitor do
 
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    if Process.alive?(pid) do
-      state[pid].sorcery_unmount(pid)
+    # Sometimes due to race conditions, mod is nil so this doesn't work
+    # When that happens, we need to not lose the pid from state, but save it for later.
+    # Next time a process unmounts, we'll handle both of them. 
+    # The cost should be negligible considering how rare it seems to be.
+    mod = state[pid]
+    if mod do
+      orphans = Map.get(state, :orphaned, [])
+      pids = [pid | orphans]
+      mod.sorcery_unmount(pids)
+      new_state = Map.delete(state, pid)
+      {:noreply, new_state}
+    else
+      state =
+        state
+        |> Map.update(:orphaned, [pid], fn orphans -> [pid | orphans] end)
+        |> Map.delete(pid)
+      {:noreply, state}
     end
-    new_state = Map.delete(state, pid)
-    {:noreply, new_state}
+    
   end
 end

--- a/lib/storage/adapters/genserver_adapter.ex
+++ b/lib/storage/adapters/genserver_adapter.ex
@@ -89,9 +89,9 @@ defmodule Sorcery.Storage.GenserverAdapter do
       end
 
 
-      def unmount(pid, opts \\ %{}) do
+      def unmount(pids, opts \\ %{}) do
         name = opts[:name] || @name
-        GenServer.cast(name, {:unmount, pid, opts})
+        GenServer.cast(name, {:unmount, pids, opts})
       end
      
       ## Callbacks
@@ -171,8 +171,10 @@ defmodule Sorcery.Storage.GenserverAdapter do
       end
 
 
-      def handle_cast({:unmount, pid, opts}, state) do
-        new_state = Sorcery.Storage.GenserverAdapter.Unmount.unmount(pid, state)
+      def handle_cast({:unmount, pids, opts}, state) do
+        new_state = Enum.reduce(pids, state, fn pid, acc ->
+          Sorcery.Storage.GenserverAdapter.Unmount.unmount(pid, acc)
+        end)
         {:noreply, new_state}
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Sorcery.MixProject do
     [
       app: :sorcery,
       name: "Sorcery",
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This could have been a potential memory leak, albeit a very slow one.

A race condition would sometimes cause the unmount function to not get called, which is how the db gets cleared as people leave.