### PR TITLE
Fix querying bug

### DIFF
--- a/lib/storage/adapters/genserver_adapter/create_portal.ex
+++ b/lib/storage/adapters/genserver_adapter/create_portal.ex
@@ -28,6 +28,7 @@ defmodule Sorcery.Storage.GenserverAdapter.CreatePortal do
     values = Enum.map(guards, fn g -> resolve_guard(g, state) end)
     {:or, values}
   end
+  defp resolve_guard({:==, attr, {ref, ref_attr}}, state), do: resolve_guard({:in, attr, {ref, ref_attr}}, state)
   defp resolve_guard({:in, attr, {ref, ref_attr}}, state) do
     ref_values = ViewPortal.view_portal(ref, state)
                 |> Enum.map(fn {_, e} -> Map.get(e, ref_attr) end)

--- a/test/storage/adapters/genserver_adapter/query_test.exs
+++ b/test/storage/adapters/genserver_adapter/query_test.exs
@@ -169,5 +169,4 @@ defmodule Sorcery.Storage.GenserverAdapter.QueryTest do
   end
 
 
-
 end


### PR DESCRIPTION
Automatically changes guards that look like:
`{:in, attr, {ref, ref_attr}}`

into:
`{:==, attr, {ref, ref_attr}}`